### PR TITLE
Form validation error

### DIFF
--- a/src/transparent-qgw-database/api-validation.ts
+++ b/src/transparent-qgw-database/api-validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TransactionType } from ".";
 
 // Helper validators
 const isAmex = (cardNum: string) => /^3[47][0-9]{13}$/.test(cardNum);
@@ -138,17 +139,7 @@ export const apiSchema = z
       .toUpperCase()
       .pipe(z.enum(["CC", "EFT"]))
       .default("CC"),
-    trans_type: z
-      .enum([
-        "CREDIT",
-        "SALES",
-        "AUTH_CAPTURE",
-        "AUTH_ONLY",
-        "RETURN",
-        "VOID",
-        "PREVIOUS_SALE",
-      ])
-      .optional(),
+    trans_type: z.nativeEnum(TransactionType).optional(),
     transID: z.string().optional(),
     ccnum: z.string().optional(),
     ccmo: z.string().optional(),

--- a/src/transparent-qgw-database/index.ts
+++ b/src/transparent-qgw-database/index.ts
@@ -1,3 +1,5 @@
+import { ZodError } from "zod";
+import { apiSchema } from "./api-validation";
 import { TransactionRequest, TransactionResponse } from "./transaction";
 
 /*
@@ -32,9 +34,10 @@ export class TransparentDbEngine {
     return TransactionResponse;
   }
 
-  validate(transactionRequest: TransactionRequest): boolean {
-    // TODO
-    return true;
+  validate(
+    directAPI: DirectAPI
+  ): { success: true; data: DirectAPI } | { success: false; error: ZodError } {
+    return apiSchema.safeParse(directAPI);
   }
 }
 


### PR DESCRIPTION
the form-validation-error branch makes sure that the TransparentDbEngine class's validate method returns both the success data and a **ZodError**.